### PR TITLE
Add DynamoDB reader lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,17 @@ The infrastructure can be seen in the following diagram:
 ![arch](architecture.png)
 
 The worker lives in [this repository](https://github.com/Carlows/styled-worker).
+
+## Dev
+
+### Deploy
+
+```
+serverless deploy -v
+```
+
+### Running Functions from cli
+
+```
+serverless invoke -f functionName -l
+```

--- a/functions/create.js
+++ b/functions/create.js
@@ -68,6 +68,10 @@ module.exports.createRecord = (event, context, callback) => {
         "styleUrl": {
           DataType: "String",
           StringValue: params.Item.styleUrl
+        },
+        recordId: {
+          DataType: "String",
+          StringValue: params.Item.id
         }
       }
     };

--- a/functions/read.js
+++ b/functions/read.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+
+var dynamoDB = new AWS.DynamoDB.DocumentClient();
+
+const defaultResponse = {
+  headers: {
+    'Content-Type': 'application/json',
+  },
+};
+
+module.exports.fetchRecords = (event, context, callback) => {
+  const params = {
+    TableName: process.env.DYNAMODB_TABLE
+  };
+
+  dynamoDB.scan(params, function (err, data) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    const response = Object.assign({}, defaultResponse, {
+      statusCode: '200',
+      body: JSON.stringify({ items: data.Items })
+    });;
+
+    callback(null, response);
+  });
+};

--- a/functions/read.js
+++ b/functions/read.js
@@ -24,7 +24,7 @@ module.exports.fetchRecords = (event, context, callback) => {
     const response = Object.assign({}, defaultResponse, {
       statusCode: '200',
       body: JSON.stringify({ items: data.Items })
-    });;
+    });
 
     callback(null, response);
   });

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,7 @@ provider:
       Action:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
+        - dynamodb:Scan
       Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/${self:provider.environment.DYNAMODB_TABLE}"
     - Effect: Allow
       Action:
@@ -36,6 +37,18 @@ functions:
       - http:
           path: records
           method: post
+          cors: true
+  fetchRecords:
+    handler: functions/read.fetchRecords
+    name: ${self:provider.stage}-fetchRecords
+    description: Reads the current records stored in DynamoDB
+    memorySize: 512
+    timeout: 10
+    reservedConcurrency: 5
+    events:
+      - http:
+          path: records
+          method: get
           cors: true
 
 resources:


### PR DESCRIPTION
# Description
This PR adds a Lambda function to read records from a DynamoDB table. The current implementation is really simple as it only fetches all the records and returns them in the response body.

## Testing instructions
1. Clone the repo
2. `npm i`
3. `serverless invoke -f fetchRecords -l`